### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.5
+aiohttp==3.8.6
 pycryptodome==3.17
 async-class==0.5.0
 voluptuous==0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 aiohttp>=3.8.5,==3.8.*
-pycryptodome==3.17
-async-class==0.5.0
-voluptuous==0.13.1
+pycryptodome>=3.17
+async-class>=0.5.0,==0.5.*
+voluptuous>=0.13.1,==0.13.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.1
-pycryptodome==3.15.0
+aiohttp==3.8.4
+pycryptodome==3.17
 async-class==0.5.0
 voluptuous==0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.6
+aiohttp>=3.8.5,==3.8.*
 pycryptodome==3.17
 async-class==0.5.0
 voluptuous==0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.4
+aiohttp==3.8.5
 pycryptodome==3.17
 async-class==0.5.0
 voluptuous==0.13.1


### PR DESCRIPTION
Updated requirments.txt with current versions of
aiohttp==3.8.4
pycryptodome==3.17

Im using remootio HACS for Home Assistant from the below repo which uses aioremootio
https://github.com/sam43434/remootio/tree/main/custom_components/remootio

Not sure if this breaks anything else but the changes above work for me after latest Home Assistant version update of 2023.3