### PR TITLE
requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.1
-pycryptodome==3.15.0
+aiohttp==3.8.5
+pycryptodome==3.17
 async-class==0.5.0
 voluptuous==0.13.1


### PR DESCRIPTION
updated the requirements .txt to get it to work with the new version of HA. 
aiohttp==3.8.5
pycryptodome==3.17
async-class==0.5.0
voluptuous==0.13.1